### PR TITLE
Supply image props correctly for width and height

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,9 +31,9 @@ export default function Home({ title, preview }: HomeProps) {
         <Image 
           alt="dreaming of nooodles logo" 
           src="https://dreamingofnoodles.s3.eu-west-1.amazonaws.com/images/dreaming-of-noodles.png" 
-          width="320" 
-          height="320"
-          layout="intrinsic" />
+          width={320} 
+          height={320}
+          layout="fixed" />
       </div>
       <Container className="mt-3">
         <div  className="lead text-center mb-3 mt-5">

--- a/pages/preview.tsx
+++ b/pages/preview.tsx
@@ -22,7 +22,12 @@ export default function Home({ allPostsData, title, preview }) {
   return (
     <Layout title={title} preview={preview}>
       <div className="d-flex justify-content-center">
-        <Image alt="dreaming of nooodles logo" src="https://dreamingofnoodles.s3.eu-west-1.amazonaws.com/images/dreaming-of-noodles.png" width="600" height="600"/>
+        <Image 
+          alt="dreaming of nooodles logo" 
+          src="https://dreamingofnoodles.s3.eu-west-1.amazonaws.com/images/dreaming-of-noodles.png" 
+          width={320} 
+          height={320}
+          layout="fixed"/>
       </div>
       <Container className="mt-3">
         <ZonePageDescription


### PR DESCRIPTION
Update the width and height props for the Image component to be numbered props instead of strings so that they work on Netlify and display an image the correct size. 